### PR TITLE
Coerceany

### DIFF
--- a/src/conventions/mlj/finite.jl
+++ b/src/conventions/mlj/finite.jl
@@ -6,21 +6,12 @@ scitype(c::CategoricalValue, ::Val{:mlj}) =
 scitype(c::CategoricalString, ::Val{:mlj}) =
     c.pool.ordered ? OrderedFactor{nlevels(c)} : Multiclass{nlevels(c)}
 
-function coerce(v::AbstractVector, ::Type{T2};
-                verbosity=1) where T2 <: Union{Missing,Finite}
-    # check if it's a Vector of Any or a CategoricalArray of Any
-    # in which case re-interpret as String to avoid errors with MLJBase.classes
-    if eltype(v) === Any || first(skipmissing(v)) isa CategoricalValue{Any,T} where T
-        if any(ismissing, v)
-            v_  = Vector{Union{Missing,String}}(undef, length(v))
-            v_ .= string.(v)
-            v_[ismissing.(v)] .= missing
-        else
-            v_ = string.(v)
-        end
-        return categorical(v_, true, ordered=false)
-    end
-    
+# for temporary hack below:
+get_(x) = get(x)
+get_(::Missing) = missing
+
+# v is already categorical here, but may need `ordering` changed
+function _finalize_finite_coerce(v, verbosity, T2)
     su = scitype_union(v)
     if su >: Missing && !(T2 >: Missing)
         verbosity > 0 && _coerce_missing_warn(T2)
@@ -28,8 +19,38 @@ function coerce(v::AbstractVector, ::Type{T2};
     if su <: T2
         return v
     end
-    return categorical(v, true, ordered=T2 <: Union{Missing,OrderedFactor})
+    return categorical(v, true, ordered=T2<:Union{Missing,OrderedFactor})
 end
+
+# if v is not a CategoricalArray:
+function coerce(v::AbstractArray,
+                ::Type{T2}; verbosity=1) where T2<:Union{Missing,Finite}
+    vtight = broadcast(identity, v)
+    vcat = categorical(vtight, true, ordered=T2<:Union{Missing,OrderedFactor})
+    return _finalize_finite_coerce(vcat, verbosity, T2)
+end
+
+# if v is a CategoricalArray except CategoricalArray{Any}:
+coerce(v::CategoricalArray,
+       ::Type{T2}; verbosity=1) where T2<:Union{Missing,Finite} =
+           _finalize_finite_coerce(v, verbosity, T2)
+
+# if v is a CategoricalArray{Any}
+function coerce(v::CategoricalArray{Any},
+                ::Type{T2}; verbosity=1)  where T2<:Union{Missing,Finite}
+
+    # AFTER CategoricalArrays 0.7.2 IS RELEASED:
+    # return _finalize_finite_coerce(broadcast(identity, v), verbosity, T2)
+
+    # TEMPORARY HACK:
+    levels_ = levels(v)
+    isordered_ = isordered(v)
+    vraw = broadcast(get_, v)
+    v_ = categorical(vraw, true, ordered=isordered_)
+    levels!(v_, levels_)
+    return _finalize_finite_coerce(v_, verbosity, T2)
+end
+
 
 ## PERFORMANT SCITYPES FOR ARRAYS
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -179,4 +179,25 @@ end
     @test all(unique(cw) .== [0.1, 0.2, 0.3])
 end
 
+@testset "Any->Multiclass (mlj)" begin
+    v1 = categorical(Any[1,2,1,2,1,missing,2])
+    v2 = Any[collect("aksldjfalsdjkfslkjdfalksjdf")...]
+    v1c = coerce(v1, Multiclass)
+    v2c = coerce(v2, Multiclass)
+    @test scitype_union(v1c) == Union{Missing,Multiclass{2}}
+    @test scitype_union(v2c) == Multiclass{7}
+    @test eltype(v1c) == Union{Missing, CategoricalString{UInt8}}
+    @test eltype(v2c) == CategoricalString{UInt8}
+
+    # normal behaviour is unchanged
+    v1 = categorical([1,2,1,2,1,2,missing])
+    v2 = collect("aksldjfalsdjkfslkjdfalksjdf")
+    v1c = coerce(v1, Multiclass)
+    v2c = coerce(v2, Multiclass)
+    @test scitype_union(v1c) == Union{Missing,Multiclass{2}}
+    @test scitype_union(v2c) == Multiclass{7}
+    @test eltype(v1c) == Union{Missing,CategoricalValue{Int64,UInt8}}
+    @test eltype(v2c) == CategoricalValue{Char,UInt8}
+end
+
 include("autotype.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,25 +155,28 @@ end
                            coerce(Any[4, 7.0, missing], Count))
     @test ismissing(y_coerced == [4, 7, missing])
     @test scitype_union(y_coerced) === Union{Missing,Count}
-#    @test scitype_union(@test_logs((:warn, r"Missing values encountered"),
-#                                   coerce([:x, :y, missing], Multiclass))) ===
-    @test scitype_union(coerce([:x, :y, missing], Multiclass)) ===
-        Union{Missing, Multiclass{2}}
-    # @test scitype_union(@test_logs((:warn, r"Missing values encountered"),
-    #                                coerce([:x, :y, missing], OrderedFactor))) ===
-    #                                    Union{Missing, OrderedFactor{2}}
-    scitype_union(coerce([:x, :y, missing], OrderedFactor)) ===
+    @test scitype_union(@test_logs((:warn, r"Missing values encountered"),
+                                   coerce([:x, :y, missing], Multiclass))) ===
+                                       Union{Missing, Multiclass{2}}
+    @test scitype_union(@test_logs((:warn, r"Missing values encountered"),
+                                coerce([:x, :y, missing], OrderedFactor))) ===
                                        Union{Missing, OrderedFactor{2}}
     # non-missing Any vectors
     @test coerce(Any[4, 7], Continuous) == [4.0, 7.0]
     @test coerce(Any[4.0, 7.0], Continuous) == [4, 7]
 
+    # Finite conversions:
+    @test scitype_union(coerce([:x, :y], Finite)) === Multiclass{2}
+    @test scitype_union(@test_logs((:warn, r"Missing values encountered"),
+                                coerce([:x, :y, missing], Finite))) ===
+                                       Union{Missing, Multiclass{2}}
 end
 
 @testset "coerce R->OF (mlj)" begin
     v = [0.1, 0.2, 0.2, 0.3, missing, 0.1]
     w = [0.1, 0.2, 0.2, 0.3, 0.1]
-    cv = coerce(v, OrderedFactor)
+    @test_logs((:warn, r"Missing values encountered"),
+                   global cv = coerce(v, OrderedFactor))
     cw = coerce(w, OrderedFactor)
     @test all(skipmissing(unique(cv)) .== [0.1, 0.2, 0.3])
     @test all(unique(cw) .== [0.1, 0.2, 0.3])
@@ -182,22 +185,24 @@ end
 @testset "Any->Multiclass (mlj)" begin
     v1 = categorical(Any[1,2,1,2,1,missing,2])
     v2 = Any[collect("aksldjfalsdjkfslkjdfalksjdf")...]
-    v1c = coerce(v1, Multiclass)
+    @test_logs((:warn, r"Missing values"),
+               global v1c = coerce(v1, Multiclass))
     v2c = coerce(v2, Multiclass)
     @test scitype_union(v1c) == Union{Missing,Multiclass{2}}
     @test scitype_union(v2c) == Multiclass{7}
-    @test eltype(v1c) == Union{Missing, CategoricalString{UInt8}}
-    @test eltype(v2c) == CategoricalString{UInt8}
+    @test eltype(v1c) <: Union{Missing, CategoricalValue{Int64}}
+    @test eltype(v2c) <: CategoricalValue{Char}
 
     # normal behaviour is unchanged
     v1 = categorical([1,2,1,2,1,2,missing])
     v2 = collect("aksldjfalsdjkfslkjdfalksjdf")
-    v1c = coerce(v1, Multiclass)
+    @test_logs((:warn, r"Missing values"),
+               global v1c = coerce(v1, Multiclass))
     v2c = coerce(v2, Multiclass)
     @test scitype_union(v1c) == Union{Missing,Multiclass{2}}
     @test scitype_union(v2c) == Multiclass{7}
-    @test eltype(v1c) == Union{Missing,CategoricalValue{Int64,UInt8}}
-    @test eltype(v2c) == CategoricalValue{Char,UInt8}
+    @test eltype(v1c) <: Union{Missing,CategoricalValue{Int64}}
+    @test eltype(v2c) <: CategoricalValue{Char}
 end
 
 include("autotype.jl")


### PR DESCRIPTION
Context: https://github.com/alan-turing-institute/MLJModels.jl/issues/126

The problem is fixed with this fix which, in essence, does the following:

```julia
v1 = categorical(Any[1,2,1,2,1,missing,2])
v2 = Any[collect("aksldjfalsdjkfslkjdfalksjdf")...]
v1c = coerce(v1, Multiclass)
v2c = coerce(v2, Multiclass)
@test eltype(v1c) == Union{Missing, CategoricalString{UInt8}}
@test eltype(v2c) == CategoricalString{UInt8}
```

I.e. vectors with `Any` when coerced to multiclass are effectively re-parsed as String.

This guarantees that `classes(...)` will not fail in a problematic way (see also https://github.com/JuliaData/CategoricalArrays.jl/pull/221); it also might just make more sense.