### PR TITLE
Support for coercion from Categorical to Count or Continuous

### DIFF
--- a/src/ScientificTypes.jl
+++ b/src/ScientificTypes.jl
@@ -10,6 +10,8 @@ export autotype
 
 using Tables, CategoricalArrays, ColorTypes
 
+const CategoricalElement{U} = Union{CategoricalValue{<:Any,U},CategoricalString{U}}
+
 # ## FOR DEFINING SCITYPES ON OBJECTS DETECTED USING TRAITS
 
 # We define a "dynamically" extended function `trait`:

--- a/src/conventions/mlj/mlj.jl
+++ b/src/conventions/mlj/mlj.jl
@@ -27,6 +27,9 @@ function coerce(y::AbstractArray{<:Union{Missing,Real}},
     return float(y)
 end
 
+_float(y::CategoricalElement) = float(y.level)
+_float(y) = float(y)
+
 # NOTE: case where the data may have been badly encoded and resulted
 # in an Any[] array a user should proceed with caution here in
 # particular: - if at one point it encounters a type for which there
@@ -39,7 +42,7 @@ function coerce(y::AbstractArray, T::Type{<:Union{Missing,Continuous}}; verbosit
     has_chars    = findfirst(e->isa(e,Char), y) !== nothing
     has_chars && verbosity > 0 && @warn "Char values will be coerced to " *
                                         "AbstractFloat (e.g. 'A' to 65.0)."
-    return float.(y)
+    return _float.(y)
 end
 
 
@@ -47,6 +50,7 @@ end
 
 _int(::Missing)  = missing
 _int(x::Integer) = x
+_int(x::CategoricalElement) = x.level
 _int(x) = Int(x) # may throw InexactError
 
 # no-op case

--- a/src/conventions/mlj/mlj.jl
+++ b/src/conventions/mlj/mlj.jl
@@ -27,7 +27,7 @@ function coerce(y::AbstractArray{<:Union{Missing,Real}},
     return float(y)
 end
 
-_float(y::CategoricalElement) = float(y.level)
+_float(y::CategoricalElement) = float(_int(y))
 _float(y) = float(y)
 
 # NOTE: case where the data may have been badly encoded and resulted
@@ -50,7 +50,7 @@ end
 
 _int(::Missing)  = missing
 _int(x::Integer) = x
-_int(x::CategoricalElement) = x.level
+_int(x::CategoricalElement) = CategoricalArrays.order(x.pool)[x.level]
 _int(x) = Int(x) # may throw InexactError
 
 # no-op case

--- a/src/conventions/mlj/mlj.jl
+++ b/src/conventions/mlj/mlj.jl
@@ -1,10 +1,10 @@
 scitype(::AbstractFloat, ::Val{:mlj}) = Continuous
 scitype(::Integer, ::Val{:mlj}) = Count
 
-_coerce_missing_warn(T) =
-    @warn "Missing values encountered coercing scitype to $T.\n"*
-          "Coerced to Union{Missing,$T} instead. "
-
+function _coerce_missing_warn(::Type{T}) where T
+    T >: Missing || @warn "Missing values encountered coercing scitype to $T.\n"*
+                          "Coerced to Union{Missing,$T} instead. "
+end
 
 # ## IMPLEMENT PERFORMANCE BOOSTING FOR ARRAYS
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -229,7 +229,7 @@ end
     y = categorical(1:10, ordered=true)
     new_order = [4, 10, 9, 7, 6, 2, 8, 3, 1, 5]
     levels!(y, new_order)
-    @test_broken all(coerce(y, Count) .== new_order)
+    @test all(coerce(y, Count) .== sortperm(new_order))
     @test all(coerce(y, Count) .== [9, 6, 8, 1, 10, 5, 4, 7, 3, 2])
 
     y = categorical([1:10..., missing, 11], ordered=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -215,4 +215,14 @@ end
     @test eltype(v2c) <: CategoricalValue{Char}
 end
 
+@testset "Cat->Count,Continuous (mlj)" begin
+    a = categorical(["a","b","a","b",missing])
+    a1 = coerce(a, Union{Count,Missing})
+    @test scitype_union(a1) == Union{Missing,Count}
+    @test all(skipmissing(a1 .== [1, 2, 1, 2, missing]))
+    a1 = coerce(a, Union{Continuous,Missing})
+    @test scitype_union(a1) == Union{Missing,Continuous}
+    @test all(skipmissing(a1 .== [1., 2., 1., 2., missing])) 
+end
+
 include("autotype.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -222,7 +222,7 @@ end
     @test all(skipmissing(a1 .== [1, 2, 1, 2, missing]))
     a1 = coerce(a, Union{Continuous,Missing})
     @test scitype_union(a1) == Union{Missing,Continuous}
-    @test all(skipmissing(a1 .== [1., 2., 1., 2., missing])) 
+    @test all(skipmissing(a1 .== [1., 2., 1., 2., missing]))
 end
 
 include("autotype.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -223,6 +223,17 @@ end
     a1 = coerce(a, Union{Continuous,Missing})
     @test scitype_union(a1) == Union{Missing,Continuous}
     @test all(skipmissing(a1 .== [1., 2., 1., 2., missing]))
+
+    # XXX
+
+    y = categorical(1:10, ordered=true)
+    new_order = [4, 10, 9, 7, 6, 2, 8, 3, 1, 5]
+    levels!(y, new_order)
+    @test_broken all(coerce(y, Count) .== new_order)
+    @test all(coerce(y, Count) .== [9, 6, 8, 1, 10, 5, 4, 7, 3, 2])
+
+    y = categorical([1:10..., missing, 11], ordered=true)
+    @test all(skipmissing(coerce(y, Union{Continuous, Missing}) .== float.([1:10...,missing,11])))
 end
 
 include("autotype.jl")


### PR DESCRIPTION
This allows

* conversion from Cat -> Int
* conversion from Cat -> Float

```julia
julia> a = categorical(["a","b","a","b"])
4-element CategoricalArray{String,1,UInt32}:
 "a"
 "b"
 "a"
 "b"

julia> coerce(a, Continuous)
4-element Array{Float64,1}:
 1.0
 2.0
 1.0
 2.0
julia> coerce(a, Count)
4-element Array{UInt32,1}:
 0x00000001
 0x00000002
 0x00000001
 0x00000002
```

and with missing as expected too

(also added a small fix, there was a warning thrown even when coercing something with missing values even if we explicitly said we wanted to coerce it to a  union type with missing)
