### PR TITLE
Hackmat (addresses #49)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ScientificTypes"
 uuid = "321657f4-b219-11e9-178b-2701a2544e81"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ScientificTypes"
 uuid = "321657f4-b219-11e9-178b-2701a2544e81"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/ScientificTypes.jl
+++ b/src/ScientificTypes.jl
@@ -204,8 +204,32 @@ function scitype(A::Arr{<:Any,N}, C::Val, ::Val{S}) where {N,S}
     end
 end
 
+
 # ## STUB FOR COERCE METHOD
 
+"""
+    coerce(A::AbstractArray, T; verbosity=1)
+
+Coerce the julia types of elements of `A` to ensure the returned array
+has `T` or `Union{Missing,T}` as the union of its element scitypes,
+according to the active convention.
+
+A warning is issued if missing values are encountered, unless
+`verbosity` is `0` or less.
+
+    julia> mlj()
+    julia> v = coerce([1, missing, 5], Continuous)
+    3-element Array{Union{Missing, Float64},1}:
+     1.0
+     missing
+     5.0
+
+    julia> scitype(v)
+    AbstractArray{Union{Missing,Continuous}, 1}
+
+See also [`scitype`](@ref), [`scitype_union`](@ref).
+
+"""
 function coerce end
 
 

--- a/src/ScientificTypes.jl
+++ b/src/ScientificTypes.jl
@@ -10,6 +10,8 @@ export autotype
 
 using Tables, CategoricalArrays, ColorTypes
 
+const CategoricalElement{U} = Union{CategoricalValue{<:Any,U},CategoricalString{U}}
+
 # ## FOR DEFINING SCITYPES ON OBJECTS DETECTED USING TRAITS
 
 # We define a "dynamically" extended function `trait`:

--- a/src/autotype.jl
+++ b/src/autotype.jl
@@ -1,10 +1,7 @@
 """
 autotype(X)
 
-Return a dictionary of suggested scitypes for each column of a table
-`X`.
-
-See also [`suggest_scitype`](@ref).
+Return a dictionary of suggested scitypes for each column of a table `X`.
 
 ## Kwargs
 
@@ -65,24 +62,24 @@ for "few" is as follows:
 1. there's ≤ 3 unique values with more than 5 rows, use `MultiClass{N}` type
 2. there's less than 10% unique values out of the number of rows **or**
     there's fewer than 100 unique values (whichever one is smaller):
-        a. if it's a Real type, return as `OrderedFactor`
-        b. if it's something else (e.g. a `String`) return as `MultiClass{N}`
+
+In both cases:
+    a. if it's a Real type, return as `OrderedFactor`
+    b. if it's something else (e.g. a `String`) return as `MultiClass{N}`
 """
 function few_to_finite(type::Type, col, nrows::Int)
     nonmissing(type) <: Finite && return type
     unique_vals  = unique(skipmissing(col))
     coltype      = eltype(col)
     nunique_vals = length(unique_vals)
-    # -----------
-    # Heuristic 1
-    if nunique_vals ≤ 3 && nrows ≥ 5
-        return T_or_Union_Missing_T(coltype, Multiclass)
-    # -----------
-    # Heuristic 2
-    elseif nunique_vals ≤ max(min(0.1 * nrows, 100), 4)
+
+    if nunique_vals ≤ 3 && nrows ≥ 5 ||             # H1
+       nunique_vals ≤ max(min(0.1 * nrows, 100), 4) # H2
+        # suggest a type
         T = sugg_finite(coltype)
         return T_or_Union_Missing_T(coltype, T)
     end
+
     return type
 end
 
@@ -123,7 +120,7 @@ end
 sugg_finite(type)
 
 Helper function to suggest a finite type corresponding to `T` when there are
-few unique values. See [`suggest_scitype`](@ref).
+few unique values.
 """
 function sugg_finite(::Type{<:Union{Missing,T}}) where T
     T <: Real && return OrderedFactor

--- a/src/conventions/mlj/mlj.jl
+++ b/src/conventions/mlj/mlj.jl
@@ -12,48 +12,28 @@ Scitype(::Type{<:Integer}, ::Val{:mlj}) = Count
 Scitype(::Type{<:AbstractFloat}, ::Val{:mlj}) = Continuous
 
 
-## COERCE VECTOR TO CONTINUOUS
+## COERCE ARRAY TO CONTINUOUS
 
-"""
-    coerce(v::AbstractVector, T; verbosity=1)
-
-Coerce the julia types of elements of `v` to ensure the returned
-vector has `T` or `Union{Missing,T}` as the union of its element
-scitypes.
-
-A warning is issued if missing values are encountered, unless
-`verbosity` is `0` or less.
-
-    julia> v = coerce([1, missing, 5], Continuous)
-    3-element Array{Union{Missing, Float64},1}:
-     1.0
-     missing
-     5.0
-
-    julia> scitype(v)
-    AbstractArray{Union{Missing,Continuous}, 1}
-
-See also [`scitype`](@ref), [`scitype_union`](@ref).
-
-"""
-function coerce(y::AbstractVector{<:Union{Missing,AbstractFloat}}, T::Type{<:Union{Missing,Continuous}};
+function coerce(y::AbstractArray{<:Union{Missing,AbstractFloat}},
+                T::Type{<:Union{Missing,Continuous}};
                 verbosity=1)
     eltype(y) >: Missing && verbosity > 0 && _coerce_missing_warn(T)
     return y
 end
 
-function coerce(y::AbstractVector{<:Union{Missing,Real}}, T::Type{<:Union{Missing,Continuous}}; verbosity=1)
+function coerce(y::AbstractArray{<:Union{Missing,Real}},
+                T::Type{<:Union{Missing,Continuous}}; verbosity=1)
     eltype(y) >: Missing && verbosity > 0 && _coerce_missing_warn(T)
     return float(y)
 end
 
-# NOTE: case where the data may have been badly encoded and resulted in an Any[] vector
-# a user should proceed with caution here in particular:
-# - if at one point it encounters a type for which there is no AbstractFloat such
-# as a String, it will error.
-# - if at one point it encounters a Char it will **not** error but return a float
-# corresponding to the Char (e.g. 65.0  for 'A') whence the warning
-function coerce(y::AbstractVector, T::Type{<:Union{Missing,Continuous}}; verbosity=1)
+# NOTE: case where the data may have been badly encoded and resulted
+# in an Any[] array a user should proceed with caution here in
+# particular: - if at one point it encounters a type for which there
+# is no AbstractFloat such as a String, it will error.  - if at one
+# point it encounters a Char it will **not** error but return a float
+# corresponding to the Char (e.g. 65.0 for 'A') whence the warning
+function coerce(y::AbstractArray, T::Type{<:Union{Missing,Continuous}}; verbosity=1)
     has_missings = findfirst(ismissing, y) !== nothing
     has_missings && verbosity > 0 && _coerce_missing_warn(T)
     has_chars    = findfirst(e->isa(e,Char), y) !== nothing
@@ -63,27 +43,30 @@ function coerce(y::AbstractVector, T::Type{<:Union{Missing,Continuous}}; verbosi
 end
 
 
-## COERCE VECTOR TO COUNT
+## COERCE ARRAY TO COUNT
 
 _int(::Missing)  = missing
 _int(x::Integer) = x
 _int(x) = Int(x) # may throw InexactError
 
 # no-op case
-function coerce(y::AbstractVector{<:Union{Missing,Integer}}, T::Type{<:Union{Missing,Count}}; verbosity=1)
+function coerce(y::AbstractArray{<:Union{Missing,Integer}},
+                T::Type{<:Union{Missing,Count}}; verbosity=1)
     eltype(y) >: Missing && verbosity > 0 && _coerce_missing_warn(T)
     return y
 end
 
 # NOTE: this will error if it encounters things like 1.5 or 1//2 (InexactError)
-function coerce(y::AbstractVector{<:Union{Missing,Real}}, T::Type{<:Union{Missing,Count}}; verbosity=1)
+function coerce(y::AbstractArray{<:Union{Missing,Real}},
+                T::Type{<:Union{Missing,Count}}; verbosity=1)
     eltype(y) >: Missing && verbosity > 0 && _coerce_missing_warn(T)
     return _int.(y)
 end
 
-# NOTE: case where the data may have been badly encoded and resulted in an Any[] vector
-# a user should proceed with caution here (see comment earlier)
-function coerce(y::AbstractVector, T::Type{<:Union{Missing,Count}}; verbosity=1)
+# NOTE: case where the data may have been badly encoded and resulted
+# in an Any[] array a user should proceed with caution here (see
+# comment earlier)
+function coerce(y::AbstractArray, T::Type{<:Union{Missing,Count}}; verbosity=1)
     has_missings = findfirst(ismissing, y) !== nothing
     has_missings && verbosity > 0 && _coerce_missing_warn(T)
     has_chars    = findfirst(e->isa(e,Char), y) !== nothing

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -37,7 +37,8 @@ function _coerce_col(X, name, types; args...)
     y = getproperty(X, name)
     if haskey(types, name)
         # HACK y isa LazyArrays.ApplyArray, see issue #49
-        if hasproperty(y, :f) && hasproperty(y, :args)
+        props = propertynames(y)
+        if :f in props && :args in props
             y = convert(Vector, y)
         end
         return coerce(y, types[name]; args...)

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -36,6 +36,10 @@ function _coerce_col(X, name, types; args...)
     Xcol = Tables.columntable(X)
     y = getproperty(X, name)
     if haskey(types, name)
+        # HACK y isa LazyArrays.ApplyArray, see issue #49
+        if hasproperty(y, :f) && hasproperty(y, :args)
+            y = convert(Vector, y)
+        end
         return coerce(y, types[name]; args...)
     else
         return y

--- a/test/autotype.jl
+++ b/test/autotype.jl
@@ -173,3 +173,12 @@ end
     @test scitype_union(Xc.v) == Union{Missing,OrderedFactor{2}}
     @test scitype_union(Xc.z) == OrderedFactor{2}
 end
+
+
+@testset "Auto for Array" begin
+    X = ones(Int, 5, 5)
+    @test autotype(X, (:discrete_to_continuous,)) == Continuous
+    @test autotype(X, :discrete_to_continuous) == Continuous
+    X = reshape([3.415 for i in 1:9], 3, 3)
+    @test autotype(X) == OrderedFactor # using :few_to_finite
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -169,7 +169,16 @@ end
     @test scitype_union(coerce([:x, :y], Finite)) === Multiclass{2}
     @test scitype_union(@test_logs((:warn, r"Missing values encountered"),
                                 coerce([:x, :y, missing], Finite))) ===
-                                       Union{Missing, Multiclass{2}}
+                                    Union{Missing, Multiclass{2}}
+
+    # More finite conversions (to check resolution of #48):
+    y = categorical([1, 2, 3, missing]) # unordered
+    yc = coerce(y, OrderedFactor)
+    @test isordered(yc)
+    @test yc[1].pool.ordered
+    scitype(y) == AbstractVector{OrderedFactor{2}}
+    scitype_union(y) == OrderedFactor{2}
+
 end
 
 @testset "coercion works for arrays too" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -224,4 +224,25 @@ end
     @test eltype(v2c) <: CategoricalValue{Char}
 end
 
+@testset "Cat->Count,Continuous (mlj)" begin
+    a = categorical(["a","b","a","b",missing])
+    a1 = coerce(a, Union{Count,Missing})
+    @test scitype_union(a1) == Union{Missing,Count}
+    @test all(skipmissing(a1 .== [1, 2, 1, 2, missing]))
+    a1 = coerce(a, Union{Continuous,Missing})
+    @test scitype_union(a1) == Union{Missing,Continuous}
+    @test all(skipmissing(a1 .== [1., 2., 1., 2., missing]))
+
+    # XXX
+
+    y = categorical(1:10, ordered=true)
+    new_order = [4, 10, 9, 7, 6, 2, 8, 3, 1, 5]
+    levels!(y, new_order)
+    @test all(coerce(y, Count) .== sortperm(new_order))
+    @test all(coerce(y, Count) .== [9, 6, 8, 1, 10, 5, 4, 7, 3, 2])
+
+    y = categorical([1:10..., missing, 11], ordered=true)
+    @test all(skipmissing(coerce(y, Union{Continuous, Missing}) .== float.([1:10...,missing,11])))
+end
+
 include("autotype.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -155,28 +155,54 @@ end
                            coerce(Any[4, 7.0, missing], Count))
     @test ismissing(y_coerced == [4, 7, missing])
     @test scitype_union(y_coerced) === Union{Missing,Count}
-#    @test scitype_union(@test_logs((:warn, r"Missing values encountered"),
-#                                   coerce([:x, :y, missing], Multiclass))) ===
-    @test scitype_union(coerce([:x, :y, missing], Multiclass)) ===
-        Union{Missing, Multiclass{2}}
-    # @test scitype_union(@test_logs((:warn, r"Missing values encountered"),
-    #                                coerce([:x, :y, missing], OrderedFactor))) ===
-    #                                    Union{Missing, OrderedFactor{2}}
-    scitype_union(coerce([:x, :y, missing], OrderedFactor)) ===
+    @test scitype_union(@test_logs((:warn, r"Missing values encountered"),
+                                   coerce([:x, :y, missing], Multiclass))) ===
+                                       Union{Missing, Multiclass{2}}
+    @test scitype_union(@test_logs((:warn, r"Missing values encountered"),
+                                coerce([:x, :y, missing], OrderedFactor))) ===
                                        Union{Missing, OrderedFactor{2}}
     # non-missing Any vectors
     @test coerce(Any[4, 7], Continuous) == [4.0, 7.0]
     @test coerce(Any[4.0, 7.0], Continuous) == [4, 7]
 
+    # Finite conversions:
+    @test scitype_union(coerce([:x, :y], Finite)) === Multiclass{2}
+    @test scitype_union(@test_logs((:warn, r"Missing values encountered"),
+                                coerce([:x, :y, missing], Finite))) ===
+                                       Union{Missing, Multiclass{2}}
 end
 
 @testset "coerce R->OF (mlj)" begin
     v = [0.1, 0.2, 0.2, 0.3, missing, 0.1]
     w = [0.1, 0.2, 0.2, 0.3, 0.1]
-    cv = coerce(v, OrderedFactor)
+    @test_logs((:warn, r"Missing values encountered"),
+                   global cv = coerce(v, OrderedFactor))
     cw = coerce(w, OrderedFactor)
     @test all(skipmissing(unique(cv)) .== [0.1, 0.2, 0.3])
     @test all(unique(cw) .== [0.1, 0.2, 0.3])
+end
+
+@testset "Any->Multiclass (mlj)" begin
+    v1 = categorical(Any[1,2,1,2,1,missing,2])
+    v2 = Any[collect("aksldjfalsdjkfslkjdfalksjdf")...]
+    @test_logs((:warn, r"Missing values"),
+               global v1c = coerce(v1, Multiclass))
+    v2c = coerce(v2, Multiclass)
+    @test scitype_union(v1c) == Union{Missing,Multiclass{2}}
+    @test scitype_union(v2c) == Multiclass{7}
+    @test eltype(v1c) <: Union{Missing, CategoricalValue{Int64}}
+    @test eltype(v2c) <: CategoricalValue{Char}
+
+    # normal behaviour is unchanged
+    v1 = categorical([1,2,1,2,1,2,missing])
+    v2 = collect("aksldjfalsdjkfslkjdfalksjdf")
+    @test_logs((:warn, r"Missing values"),
+               global v1c = coerce(v1, Multiclass))
+    v2c = coerce(v2, Multiclass)
+    @test scitype_union(v1c) == Union{Missing,Multiclass{2}}
+    @test scitype_union(v2c) == Multiclass{7}
+    @test eltype(v1c) <: Union{Missing,CategoricalValue{Int64}}
+    @test eltype(v2c) <: CategoricalValue{Char}
 end
 
 include("autotype.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -172,6 +172,16 @@ end
                                        Union{Missing, Multiclass{2}}
 end
 
+@testset "coercion works for arrays too" begin
+    A = rand(Int, 2, 3)
+    z = rand(Char, 2, 3)
+    y = Any[1.0 2; 3 4]
+    @test scitype_union(coerce(A, Continuous)) == Continuous
+    @test scitype_union(coerce(A, OrderedFactor)) <: OrderedFactor
+    @test scitype_union(coerce(z, Multiclass)) <: Multiclass
+    @test scitype_union(coerce(y, Count)) === Count
+end
+
 @testset "coerce R->OF (mlj)" begin
     v = [0.1, 0.2, 0.2, 0.3, missing, 0.1]
     w = [0.1, 0.2, 0.2, 0.3, 0.1]


### PR DESCRIPTION
This is a hack that solves the issue discussed in #49, it could be temporarily implemented while we wait to get a better way from https://github.com/JuliaData/Tables.jl/issues/122 

The hack  is that I don't want to add LazyArrays as a dependency, so I can't explicitly  check that things are LazyArrays, but I can check  their properties, and an `ApplyArray` has 2 properties: `:f` and `:args`, the bet is that temporarily this is enough to uniquely  identify such an array, in  which case a  conversion to a hard Vector is made.

This solves the issue in  #49 on my side and I would suggest we bring that in while waiting for a better solution? (unless there is already  a better solution)