### PR TITLE
Element Scitype

### DIFF
--- a/src/ScientificTypes.jl
+++ b/src/ScientificTypes.jl
@@ -4,7 +4,7 @@ export Scientific, Found, Unknown, Finite, Infinite
 export OrderedFactor, Multiclass, Count, Continuous
 export Binary, Table
 export ColorImage, GrayImage
-export scitype, scitype_union, scitypes, coerce, schema
+export scitype, scitype_union, scitypes, coerce, schema, elscitype
 export mlj
 export autotype
 
@@ -138,6 +138,17 @@ scitype_union(A) = reduce((a,b)->Union{a,b}, (scitype(el) for el in A))
 
 scitype(t::Tuple, ::Val) = Tuple{scitype.(t)...}
 
+
+_get_elscitype(st::Type{AbstractArray{T,N}}) where {T,N} = T
+
+"""
+elscitype(A)
+
+Return the scitype of elements of A. Unlike `scitype_union`, this does not check the scitype of
+each element, rather it takes the global scitype which is `AbstractArray{T,N}` and extracts
+the element scitype from the `T`.
+"""
+elscitype(X::AbstractArray) = scitype(X) |> _get_elscitype
 
 # ## SCITYPES OF ARRAYS
 

--- a/test/autotype.jl
+++ b/test/autotype.jl
@@ -182,3 +182,18 @@ end
     X = reshape([3.415 for i in 1:9], 3, 3)
     @test autotype(X) == OrderedFactor # using :few_to_finite
 end
+
+
+@testset "elscitype" begin
+    X = randn(5, 5)
+    @test scitype(X) == AbstractArray{Continuous, 2}
+    @test elscitype(X) == Continuous
+    X = [1, 2, missing, 5]
+    @test elscitype(X) == Union{Missing,Count}
+    X = categorical([1, 2, 3, missing, 2, 1, missing])
+    @test elscitype(X) == Union{Missing,Multiclass{3}}
+    X = categorical("lksfjalksjdflkjsdlkfjasldkfj" |> collect)
+    @test elscitype(X) <: Multiclass
+    X = coerce(categorical([1,2,3,1,2,3]), OrderedFactor)
+    @test elscitype(X) <: Union{Missing,OrderedFactor}
+end


### PR DESCRIPTION
See #48 , this adds a functionality which can be used instead of  scitype_union in many  places (in particular, in MLJBase to test whether something is ordered  in  confusion matrix stuff)

Also it doesn't suffer from the `ordered!` issue...

PS: unless  there's a strong reason not  to, I would really like to have this complementing `scitype_union` (even if it gets properly fixed) and explain in the docs the corner cases where you'd want to consider  `scitype_union`. But generally this is the function that I wanted  to  use when using `scitype_union`.