### PR TITLE
added elscitype function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,16 +9,16 @@ ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-CategoricalArrays = "^0.7"
+CategoricalArrays = "^0.7.3"
 ColorTypes = "^0.8"
 Tables = "^0.2"
 julia = "1"
 
 [extras]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 
 [targets]
 test = ["Random", "Test", "CSV", "DataFrames"]

--- a/src/ScientificTypes.jl
+++ b/src/ScientificTypes.jl
@@ -4,7 +4,7 @@ export Scientific, Found, Unknown, Finite, Infinite
 export OrderedFactor, Multiclass, Count, Continuous
 export Binary, Table
 export ColorImage, GrayImage
-export scitype, scitype_union, scitypes, coerce, coerce!, schema
+export scitype, scitype_union, scitypes, elscitype, coerce, coerce!, schema
 export mlj
 export autotype
 

--- a/src/coerce.jl
+++ b/src/coerce.jl
@@ -66,7 +66,15 @@ function coerce_df!(df, pairs::Pair{Symbol}...; verbosity=1)
     types = Dict(pairs)
     for name in names
         name in keys(types) || continue
-        df[!, name] = coerce(df[!, name], types[name])
+        # for DataFrames >= 0.19 df[!, name] = coerce(df[!, name], types(name))
+        # but we want something that works more robustly... even for older DataFrames
+        # the only way to do this is to use the `df.name = something` but we cannot use
+        # setindex! which will throw a deprecation warning...
+        name_str = "$name"
+        ex = quote
+            $df.$name = coerce($df.$name, $types[Symbol($name_str)])
+        end
+        eval(ex)
     end
     return df
 end

--- a/src/scitype.jl
+++ b/src/scitype.jl
@@ -93,3 +93,17 @@ function scitype(A::Arr{<:Any,N}, C::Val, ::Val{S}) where {N,S}
         end
     end
 end
+
+
+_get_elscitype(st::Type{AbstractArray{T,N}}) where {T,N} = T
+
+"""
+elscitype(A)
+
+Return the scitype of elements of A. Unlike `scitype_union`, this does, in
+general, not check the scitype of each element, rather it takes the global
+scitype which is `AbstractArray{T,N}` and extracts the element scitype from
+the `T`. Note however that, in some corner cases, `scitype` does check all
+elements in which case `elscitype` also will.
+"""
+elscitype(X::AbstractArray) = scitype(X) |> _get_elscitype

--- a/test/basic_tests.jl
+++ b/test/basic_tests.jl
@@ -14,14 +14,26 @@ A = Any[2 4.5;
         6 4.5]
 
 @testset "scitype_union" begin
-
     @test scitype_union(A) == Union{Count,Continuous}
     @test scitype_union(randn(1000000)) == Continuous
     @test scitype_union(1) == Count
     @test scitype_union([1]) == Count
     @test scitype_union(Any[1]) == Count
     @test scitype_union([1, 2.0, "3"]) == Union{Continuous, Count, Unknown}
+end
 
+@testset "elscitype" begin
+    X = randn(5, 5)
+    @test scitype(X) == AbstractArray{Continuous, 2}
+    @test elscitype(X) == Continuous
+    X = [1, 2, missing, 5]
+    @test elscitype(X) == Union{Missing,Count}
+    X = categorical([1, 2, 3, missing, 2, 1, missing])
+    @test elscitype(X) == Union{Missing,Multiclass{3}}
+    X = categorical("lksfjalksjdflkjsdlkfjasldkfj" |> collect)
+    @test elscitype(X) <: Multiclass
+    X = coerce(categorical([1,2,3,1,2,3]), OrderedFactor)
+    @test elscitype(X) <: Union{Missing,OrderedFactor}
 end
 
 @testset "Arrays" begin


### PR DESCRIPTION
* fixed the docstring of  `elscitype` following review in #58 
* added explicit lower bound on CategoricalArrays to 0.7.3 
* the bump to  CA.jl and subsequent test made me realise that the  in-place coercion would only work with DataFrames `>=0.19` due  to the use of the syntax `df[!, name]`, unfortunately the way around that wouldn't raise deprecation warnings is to use a macro.
  * indeed for some reason now travis uses dataframes `0.18.4` and  that's what made my  first  test fail.

I'll merge this as the changes were previously approved. 