### PR TITLE
Coercion improvements

### DIFF
--- a/src/coerce.jl
+++ b/src/coerce.jl
@@ -1,4 +1,4 @@
-function _coerce_col(X, name, types_dict; args...)
+function _coerce_col(X, name, types_dict::Dict; args...)
     y = getproperty(X, name)
     if haskey(types_dict, name)
         return coerce(y, types_dict[name]; args...)
@@ -47,7 +47,7 @@ coerce(X, types_pairs::Pair{Symbol,<:Type}...; kw...) = coerce(X, Dict(types_pai
 function coerce(X, types_pairs::Pair{<:Type,<:Type}...; kw...)
     from_types = [tp.first  for tp in types_pairs]
     to_types   = [tp.second for tp in types_pairs]
-    types_dict = Dict()
+    types_dict = Dict{Symbol,Type}()
     # retrieve the names that match the from_types
     sch = schema(X)
     for (name, st) in zip(sch.names, sch.scitypes)

--- a/test/basic_tests.jl
+++ b/test/basic_tests.jl
@@ -234,8 +234,6 @@ end
     @test scitype_union(a1) == Union{Missing,Continuous}
     @test all(skipmissing(a1 .== [1., 2., 1., 2., missing]))
 
-    # XXX
-
     y = categorical(1:10, ordered=true)
     new_order = [4, 10, 9, 7, 6, 2, 8, 3, 1, 5]
     levels!(y, new_order)
@@ -244,4 +242,16 @@ end
 
     y = categorical([1:10..., missing, 11], ordered=true)
     @test all(skipmissing(coerce(y, Union{Continuous, Missing}) .== float.([1:10...,missing,11])))
+end
+
+# issue #62
+@testset "Type=>Type coerce" begin
+    X = (x=[1,2,1,2,5,1,0,7],
+         y=[0,1,0,1,0,1,0,1])
+    Xc = coerce(X, :y=>OrderedFactor)
+    Xc = coerce(Xc, Count=>Continuous)
+    @test elscitype(Xc.x) == Continuous
+    @test elscitype(Xc.y) == OrderedFactor{2}
+    Xc = coerce(Xc, OrderedFactor=>Count)
+    @test elscitype(Xc.y) == Count
 end

--- a/test/basic_tests.jl
+++ b/test/basic_tests.jl
@@ -247,11 +247,19 @@ end
 # issue #62
 @testset "Type=>Type coerce" begin
     X = (x=[1,2,1,2,5,1,0,7],
-         y=[0,1,0,1,0,1,0,1])
+         y=[0,1,0,1,0,1,0,1],
+         z=['a','b','a','b','a','a',missing,missing])
     Xc = coerce(X, :y=>OrderedFactor)
     Xc = coerce(Xc, Count=>Continuous)
     @test elscitype(Xc.x) == Continuous
     @test elscitype(Xc.y) == OrderedFactor{2}
     Xc = coerce(Xc, OrderedFactor=>Count)
     @test elscitype(Xc.y) == Count
+    Xc = coerce(Xc, :z=>Multiclass, verbosity=0)
+    Xc = coerce(Xc, Multiclass=>OrderedFactor)
+    @test elscitype(Xc.z) == Union{Missing,OrderedFactor{2}}
+    Xc = coerce(X, Count=>Continuous, Unknown=>Multiclass)
+    @test elscitype(Xc.x) == Continuous
+    @test elscitype(Xc.y) == Continuous
+    @test elscitype(Xc.z) == Union{Missing,Multiclass{2}}
 end


### PR DESCRIPTION
* closes #61 (removes  explicit LazyArray  check as it's not needed anymore)
* closes #62, allows to do `coerce(X, Count=>Continuous, Unknown=>Multiclass)`, deals with Missing too.