### PR TITLE
Add info method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.2.7"
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]

--- a/src/ScientificTypes.jl
+++ b/src/ScientificTypes.jl
@@ -4,7 +4,7 @@ export Scientific, Found, Unknown, Finite, Infinite
 export OrderedFactor, Multiclass, Count, Continuous
 export Binary, Table
 export ColorImage, GrayImage
-export scitype, scitype_union, scitypes, elscitype, coerce, coerce!, schema
+export scitype, scitype_union, elscitype, coerce, coerce!, schema
 export info
 export mlj
 export autotype

--- a/src/ScientificTypes.jl
+++ b/src/ScientificTypes.jl
@@ -5,14 +5,17 @@ export OrderedFactor, Multiclass, Count, Continuous
 export Binary, Table
 export ColorImage, GrayImage
 export scitype, scitype_union, scitypes, elscitype, coerce, coerce!, schema
+export info
 export mlj
 export autotype
 
 using Tables, CategoricalArrays, ColorTypes
 
-const CategoricalElement{U} = Union{CategoricalValue{<:Any,U},CategoricalString{U}}
+const CategoricalElement{U} =
+    Union{CategoricalValue{<:Any,U},CategoricalString{U}}
 
-# ## FOR DEFINING SCITYPES ON OBJECTS DETECTED USING TRAITS
+
+# ## FOR DETECTING OBJECTS BASED ON TRAITS
 
 # We define a "dynamically" extended function `trait`:
 
@@ -26,10 +29,29 @@ end
 
 # Explanation: For example, if Tables.jl is loaded and one does
 # `TRAIT_FUNCTION_GIVEN_NAME[:table] = Tables.is_table` then
-# `trait(X)` returns `:table` on any Tables.jl table, and `:other`
-# otherwise. There is an understanding here that no two trait
-# functions added to the dictionary values can be simultaneously true
-# on two julia objects.
+# `trait(X)` returns `:table` on any Tables.jl table. There is an
+# understanding here that no two trait functions added to the
+# dictionary values can be simultaneously true on two julia objects.
+
+# External packages should extend the dictionary
+# TRAIT_FUNCTION_GIVEN_NAME in their __init__ function.
+
+
+"""
+
+    info(object)
+
+Returns metadata associated with some object, typically a named tuple
+keyed on a set of object traits.
+
+*Notes on overloading:* If the class of objects is detected by its
+type, `info` can be overloaded in the usual way.  If the class of
+objects is detected by the value of `ScientificTypes.trait(object)` -
+say if this value is `:some_symbol` - then one should define a method
+`info(object, ::Val{:some_symbol})`.
+
+"""
+info(object) = info(object, Val(ScientificTypes.trait(object)))
 
 
 # ## CONVENTIONS

--- a/src/ScientificTypes.jl
+++ b/src/ScientificTypes.jl
@@ -9,6 +9,9 @@ export info
 export mlj
 export autotype
 
+# re-export from CategoricalArrays:
+export categorical
+
 using Tables, CategoricalArrays, ColorTypes, PrettyTables
 
 const CategoricalElement{U} =

--- a/src/ScientificTypes.jl
+++ b/src/ScientificTypes.jl
@@ -9,7 +9,7 @@ export info
 export mlj
 export autotype
 
-using Tables, CategoricalArrays, ColorTypes
+using Tables, CategoricalArrays, ColorTypes, PrettyTables
 
 const CategoricalElement{U} =
     Union{CategoricalValue{<:Any,U},CategoricalString{U}}

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -2,30 +2,55 @@
 
 struct Schema{names, types, scitypes, nrows} end
 
-Schema(names::Tuple{Vararg{Symbol}}, types::Type{T}, scitypes::Type{S}, nrows::Integer) where {T<:Tuple,S<:Tuple} = Schema{names, T, S, nrows}()
-Schema(names, types, scitypes, nrows) = Schema{Tuple(Base.map(Symbol, names)), Tuple{types...}, Tuple{scitypes...}, nrows}()
+Schema(names::Tuple{Vararg{Symbol}},
+       types::Type{T},
+       scitypes::Type{S},
+       nrows::Integer) where {T<:Tuple,S<:Tuple} =
+           Schema{names, T, S, nrows}()
+Schema(names, types, scitypes, nrows) =
+    Schema{Tuple(Base.map(Symbol, names)),
+           Tuple{types...}, Tuple{scitypes...}, nrows}()
 
-function Base.getproperty(sch::Schema{names, types, scitypes, nrows}, field::Symbol) where {names, types, scitypes, nrows}
+boogie(t) = Tuple(fieldtype(t, i) for i = 1:fieldcount(t))
+boogie_woogie(t) = collect(boogie(t))
+
+function Base.getproperty(sch::Schema{names, types, scitypes, nrows},
+                          field::Symbol) where {names, types, scitypes, nrows}
+
     if field === :names
         return names
     elseif field === :types
-        return types === nothing ? nothing : Tuple(fieldtype(types, i) for i = 1:fieldcount(types))
+        return types === nothing ? nothing : boogie(types)
     elseif field === :scitypes
-        return scitypes === nothing ? nothing : Tuple(fieldtype(scitypes, i) for i = 1:fieldcount(scitypes))
+        return scitypes === nothing ? nothing : boogie(scitypes)
     elseif field === :nrows
         return nrows === nothing ? nothing : nrows
+    elseif field === :table
+        return (names=collect(names), types=boogie_woogie(types),
+                scitypes=boogie_woogie(scitypes))
     else
         throw(ArgumentError("unsupported property for ScientificTypes.Schema"))
     end
 end
 
-Base.propertynames(sch::Schema) = (:names, :types, :scitypes, :nrows)
+Base.propertynames(sch::Schema) = (:names, :types, :scitypes, :nrows, :table)
 
-_as_named_tuple(s::Schema) = NamedTuple{(:names, :types, :scitypes, :nrows)}((s.names, s.types, s.scitypes, s.nrows))
+_as_named_tuple(s::Schema) =
+    NamedTuple{(:names, :types, :scitypes, :nrows)}((s.names,
+                                                     s.types,
+                                                     s.scitypes,
+                                                     s.nrows))
 
 function Base.show(io::IO, ::MIME"text/plain", s::Schema)
-    show(io, MIME("text/plain"), _as_named_tuple(s))
+    data = Tables.matrix(s.table)
+    header = ["_.names", "_.types", "_.scitypes"]
+    PrettyTables.pretty_table(data, header;
+                              header_crayon=Crayon(bold=false),
+                              alignment=:l)
+    println("_.nrows = $(s.nrows)")
 end
+
+Base.show(io::IO, s::Schema) = print(io, "Schema{...}()")
 
 
 """

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -44,10 +44,11 @@ _as_named_tuple(s::Schema) =
 function Base.show(io::IO, ::MIME"text/plain", s::Schema)
     data = Tables.matrix(s.table)
     header = ["_.names", "_.types", "_.scitypes"]
+    println(io, "_.table = ")
     PrettyTables.pretty_table(data, header;
                               header_crayon=Crayon(bold=false),
                               alignment=:l)
-    println("_.nrows = $(s.nrows)")
+    println(io, "_.nrows = $(s.nrows)")
 end
 
 Base.show(io::IO, s::Schema) = print(io, "Schema{...}()")

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -53,6 +53,7 @@ end
 
 Base.show(io::IO, s::Schema) = print(io, "Schema{...}()")
 
+info(object, ::Val{:table}) = schema(object)
 
 """
     schema(X)

--- a/test/basic_tests.jl
+++ b/test/basic_tests.jl
@@ -1,3 +1,11 @@
+@testset "info" begin
+    isjunk(::Any) = false
+    isjunk(s::String) = s == "junk" ? true : false
+    ScientificTypes.TRAIT_FUNCTION_GIVEN_NAME[:junk] = isjunk
+    ScientificTypes.info(object, ::Val{:junk}) = length(object)
+    @test info("junk") == 4
+end
+
 @testset "Finite and Infinite" begin
     cv = categorical([:x, :y])
     c = cv[1]

--- a/test/type_tests.jl
+++ b/test/type_tests.jl
@@ -20,6 +20,7 @@ end
         w = rand(5)
         )
     s = schema(X)
+    @test info(X) == schema(X)
     @test s.scitypes == (Continuous, Count, Multiclass{4}, Continuous)
     @test s.types == (Float64, Int64, CategoricalValue{Char,UInt32}, Float64)
     @test s.nrows == 5

--- a/test/type_tests.jl
+++ b/test/type_tests.jl
@@ -6,10 +6,9 @@
     @test sch.nrows == 5
 
     @test_throws ArgumentError sch.something
-    @test propertynames(sch) == (:names, :types, :scitypes, :nrows)
+    @test propertynames(sch) == (:names, :types, :scitypes, :nrows, :table)
     snt = S._as_named_tuple(sch)
     @test snt isa NamedTuple
-    @test propertynames(snt) == propertynames(sch)
     @test snt.names == sch.names
 end
 


### PR DESCRIPTION
Move info method from MLJBase. Needed to facilitate a future migration of measures API out of MLJBase to a package independent of MLJBase. Do `?info` for details.

Also improve show for schema