### PR TITLE
For 0.3.0 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ScientificTypes"
 uuid = "321657f4-b219-11e9-178b-2701a2544e81"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.2.6"
+version = "0.2.7"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ScientificTypes"
 uuid = "321657f4-b219-11e9-178b-2701a2544e81"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.2.7"
+version = "0.3.0"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -100,6 +100,16 @@ schema(Xfixed).scitypes
 
 Note that, as it encountered missing values in `height` it coerced the type to `Union{Missing,Continuous}`.
 
+One can also make a replacement based on existing scientific type, instead of feature name:
+
+```@example 2
+X  = (x = [1, 2, 3],
+      y = rand(3),
+      z = [10, 20, 30])
+Xfixed = coerce(X, Count=>Continuous)
+schema(Xfixed).scitypes
+```
+
 Finally there is a `coerce!` method that does in-place coercion provided the data structure allows it (at the moment only `DataFrames.DataFrame` is supported).
 
 ## Notes

--- a/src/coerce.jl
+++ b/src/coerce.jl
@@ -14,10 +14,8 @@ coerce(X, d::AbstractDict; verbosity=1)
 Return a copy of the table `X` with the scitypes of the specified
 columns coerced to those specified, or to missing-value versions of
 these scitypes, with warnings issued (for positive `verbosity`).
+
 Alternatively, the specifications can be wrapped in a dictionary.
-
-
-### Example
 
 ```julia
 using CategoricalArrays, DataFrames, Tables
@@ -25,9 +23,22 @@ X = DataFrame(name=["Siri", "Robo", "Alexa", "Cortana"],
               height=[152, missing, 148, 163],
               rating=[1, 5, 2, 1])
 coerce(X, :name=>Multiclass, :height=>Continuous, :rating=>OrderedFactor)
+```
+
+If a scientific type `T` is specified in place of a column name, then
+*all* columns with scientific element type subtyping `Union{T,Missing}`
+will be converted to the new specified type:
+
+```julia
+X  = (x = [1, 2, 3],
+      y = rand(3),
+      z = [10, 20, 30])
+Xfixed = coerce(X, Count=>Continuous)
+schema(Xfixed).scitypes # (Continuous, Continuous, Continuous)
+```
 
 See also [`scitype`](@ref), [`schema`](@ref).
-```
+
 """
 function coerce(X, types_dict::Dict; verbosity=1)
     isempty(types_dict) && return X

--- a/src/coerce.jl
+++ b/src/coerce.jl
@@ -27,7 +27,7 @@ coerce(X, :name=>Multiclass, :height=>Continuous, :rating=>OrderedFactor)
 
 If a scientific type `T` is specified in place of a column name, then
 *all* columns with scientific element type subtyping `Union{T,Missing}`
-will be converted to the new specified type:
+will be coerced to the new specified scitype:
 
 ```julia
 X  = (x = [1, 2, 3],

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -45,7 +45,7 @@ function Base.show(io::IO, ::MIME"text/plain", s::Schema)
     data = Tables.matrix(s.table)
     header = ["_.names", "_.types", "_.scitypes"]
     println(io, "_.table = ")
-    PrettyTables.pretty_table(data, header;
+    PrettyTables.pretty_table(io, data, header;
                               header_crayon=Crayon(bold=false),
                               alignment=:l)
     println(io, "_.nrows = $(s.nrows)")


### PR DESCRIPTION
- Add an `info` method (migrated from MLJBase) 
- Add `table` property to `Schema` instances and improve the `show` method for same
 