### PR TITLE
adjusting test for CSV > 0.5.19

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ScientificTypes"
 uuid = "321657f4-b219-11e9-178b-2701a2544e81"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/test/extra_tests.jl
+++ b/test/extra_tests.jl
@@ -6,8 +6,8 @@ if VERSION ≥ v"1.3.0-"
 
    data = CSV.read(tmp, threaded=true)
 
-   # data.Column1 and data.Column2 are LazyArrays
-   @test startswith("$(typeof(data.Column1))", "LazyArrays.")
+   # data.Column1 and data.Column2 are Column2 (as of CSV 5.19)
+   @test startswith("$(typeof(data.Column1))", "CSV.Column2")
 
    dc = coerce(data, autotype(data, :discrete_to_continuous))
    @test scitype(dc) == Table{AbstractArray{Continuous,1}}


### PR DESCRIPTION
CSV 0.5.19 dropped the LazyArray thing, there was a test explicitly associated with that.