### PR TITLE
The scitype of `[missing, missing]` should be Missing

### DIFF
--- a/src/scitype.jl
+++ b/src/scitype.jl
@@ -72,6 +72,9 @@ Scitype(::Type{Any}, ::Convention) = Unknown
 Scitype(::Type{Union{T,Missing}}, C::Convention) where T =
     Union{Missing,Scitype(T, C)}
 
+# for the case Missing, we return Missing
+Scitype(::Type{Missing}, C::Convention) = Missing
+
 # Broadcasting over arrays
 
 scitype(A::Arr{T}, C::Convention, ::Val{:other}; kw...) where T =

--- a/test/scitype.jl
+++ b/test/scitype.jl
@@ -16,6 +16,8 @@
 
     Xm = Any[missing, missing]
     @test scitype(Xm) == AbstractVector{Missing}
+    
+    @test scitype([missing, missing]) == AbstractVector{Missing}
 end
 
 @testset "scitype2" begin


### PR DESCRIPTION
Fixes #105 

With this patch:

```julia
julia> import ScientificTypes

julia> import MLJScientificTypes

julia> ScientificTypes.set_convention(MLJScientificTypes.MLJ())

julia> ScientificTypes.scitype([1, 2])
AbstractVector{ScientificTypes.Count} = AbstractArray{ScientificTypes.Count,1}

julia> ScientificTypes.scitype([1.0, 2.0])
AbstractVector{ScientificTypes.Continuous} = AbstractArray{ScientificTypes.Continuous,1}

julia> ScientificTypes.scitype(["foo", "bar"])
AbstractVector{ScientificTypes.Textual} = AbstractArray{ScientificTypes.Textual,1}

julia> ScientificTypes.scitype([1, missing])
AbstractVector{Union{Missing, ScientificTypes.Count}} = AbstractArray{Union{Missing, ScientificTypes.Count},1}

julia> ScientificTypes.scitype([1.0, missing])
AbstractVector{Union{Missing, ScientificTypes.Continuous}} = AbstractArray{Union{Missing, ScientificTypes.Continuous},1}

julia> ScientificTypes.scitype(["foo", missing])
AbstractVector{Union{Missing, ScientificTypes.Textual}} = AbstractArray{Union{Missing, ScientificTypes.Textual},1}

julia> ScientificTypes.scitype([missing, missing])
AbstractVector{Missing} = AbstractArray{Missing,1}

julia> ScientificTypes.scitype(Missing[])
AbstractVector{Missing} = AbstractArray{Missing,1}
```

cc: @ablaom 