### PR TITLE
Stop schema getting truncated in display

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ScientificTypes"
 uuid = "321657f4-b219-11e9-178b-2701a2544e81"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "3.2.0"
+version = "3.3.0"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -2,6 +2,7 @@
 Functionalities supporting the schema of `X` when `X` is a `Tables.jl`
 compatible table.
 =#
+
 struct Schema{names, scitypes, types}
     storednames::Union{Nothing, Vector{Symbol}}
     storedscitypes::Union{Nothing, Vector{Type}}
@@ -41,7 +42,7 @@ end
 stored(::Nothing) = false
 tuple_of_symbols(x::NTuple{N, Symbol}) where {N} = x
 tuple_of_symbols(x) = Tuple(map(Symbol, x))
- 
+
 @inline function Schema(names, scitypes, types; stored::Bool=false)
     if stored || length(names) > SCHEMA_SPECIALIZATION_THRESHOLD
         return Schema{nothing, nothing, nothing}(
@@ -49,7 +50,7 @@ tuple_of_symbols(x) = Tuple(map(Symbol, x))
             Type[T for T in scitypes],
             Type[T for T in types]
         )
-    else 
+    else
         return Schema{tuple_of_symbols(names), Tuple{scitypes...}, Tuple{types...}}()
     end
 end
@@ -59,18 +60,18 @@ if VERSION < v"1.1"
 end
 
 # Note that `getproperty(::Schema, :name)`, `getproperty(::Schema, :scitypes)`
-# and `getproperty(::Schema, :types)` cannot return `nothing` even though the 
+# and `getproperty(::Schema, :types)` cannot return `nothing` even though the
 # definition below allows for this case. This is because the nature of the `schema`
-# function defined below.   
+# function defined below.
 function Base.getproperty(sch::Schema{names, scitypes, types},
                           field::Symbol) where {names, scitypes, types}
     if field === :names
         return names === nothing ? getfield(sch, :storednames) : names
     elseif field === :scitypes
-        return scitypes === nothing ? 
+        return scitypes === nothing ?
             (S = getfield(sch, :storedscitypes); S !== nothing ? S : nothing) : fieldtypes(scitypes)
     elseif field === :types
-        return types === nothing ? 
+        return types === nothing ?
             (T = getfield(sch, :storedtypes); T !== nothing ? T : nothing) : fieldtypes(types)
     else
         throw(ArgumentError("unsupported property for ScientificTypes.Schema"))
@@ -140,12 +141,12 @@ function _cols_schema(cols, sch::Tables.Schema{names, types}) where {names, type
     else
         stypes = if types === nothing
             Type[
-                elscitype(Tables.getcolumn(cols, names[i])) 
+                elscitype(Tables.getcolumn(cols, names[i]))
                 for i in Base.OneTo(N)
             ]
         else
             Type[
-                elscitype(Tables.getcolumn(cols, fieldtype(types, i), i, names[i])) 
+                elscitype(Tables.getcolumn(cols, fieldtype(types, i), i, names[i]))
                 for i in Base.OneTo(N)
             ]
         end
@@ -158,7 +159,7 @@ end
     if @generated
         stypes = if types === nothing
             (
-                :(elscitype(Tables.getcolumn(cols, $(Meta.QuoteNode(names[i]))))) 
+                :(elscitype(Tables.getcolumn(cols, $(Meta.QuoteNode(names[i])))))
                 for i in Base.OneTo(N)
             )
         else
@@ -169,29 +170,29 @@ end
                             cols, $(fieldtype(types, i)), $i,  $(Meta.QuoteNode(names[i]))
                         )
                     )
-                end 
+                end
                 for i in Base.OneTo(N)
             )
         end
-        
+
         return :(Schema(names, Tuple{$(stypes...)}, types))
-        
+
     else
-        
-        stypes = if types === nothing 
+
+        stypes = if types === nothing
             (
-                elscitype(Tables.getcolumn(cols, names[i])) 
+                elscitype(Tables.getcolumn(cols, names[i]))
                 for i in Base.OneTo(N)
             )
         else
             (
-                elscitype(Tables.getcolumn(cols, fieldtype(types, i), i, names[i])) 
+                elscitype(Tables.getcolumn(cols, fieldtype(types, i), i, names[i]))
                 for i in Base.OneTo(N)
             )
         end
 
         return Schema(names, Tuple{stypes...}, types)
-        
+
     end
 
 end
@@ -248,7 +249,13 @@ function Base.show(io::IO, ::MIME"text/plain", s::Schema)
     style = PrettyTables.TextTableStyle(
         first_line_column_label = PrettyTables.crayon"black",
     )
-
     column_labels = [["names", "scitypes", "types"],]
-    pretty_table(io, s; column_labels, style, alignment=:l)
+    pretty_table(
+        io,
+        s;
+        column_labels,
+        style,
+        fit_table_in_display_vertically=false,
+        alignment=:l,
+    )
 end

--- a/test/schema.jl
+++ b/test/schema.jl
@@ -43,6 +43,13 @@
         "└───────┴────────────┴─────────┘\n"
 end
 
+@testset "all rows of schema are displayed" begin
+    table = Tables.table(fill("data", 2, 200))
+    str = sprint(show, MIME("text/plain"), ScientificTypes.schema(table))
+    nrows =  length(split(str, "\n")) - 5
+    @test nrows == 200
+end
+
 struct MySchemalessTable{U, V}
     x::Vector{U}
     y::Vector{V}


### PR DESCRIPTION
This is super annoying. Even some rather short schema get truncated, and it's difficult to predict when. Example:

```
┌───────────────────────────┬───────────────────────────────┬───────────────────
│ names                     │ scitypes                      │ types            ⋯
├───────────────────────────┼───────────────────────────────┼───────────────────
│ age                       │ Union{Missing, Continuous}    │ Union{Missing, F ⋯
│ sex                       │ Union{Missing, Multiclass{2}} │ Union{Missing, C ⋯
│ on_thyroxine              │ OrderedFactor{2}              │ CategoricalValue ⋯
│ query_on_thyroxine        │ OrderedFactor{2}              │ CategoricalValue ⋯
│ on_antithyroid_medication │ OrderedFactor{2}              │ CategoricalValue ⋯
│ sick                      │ OrderedFactor{2}              │ CategoricalValue ⋯
│ pregnant                  │ OrderedFactor{2}              │ CategoricalValue ⋯
│ thyroid_surgery           │ OrderedFactor{2}              │ CategoricalValue ⋯
│ I131_treatment            │ OrderedFactor{2}              │ CategoricalValue ⋯
│ query_hypothyroid         │ OrderedFactor{2}              │ CategoricalValue ⋯
│ query_hyperthyroid        │ OrderedFactor{2}              │ CategoricalValue ⋯
│ lithium                   │ OrderedFactor{2}              │ CategoricalValue ⋯
│ goitre                    │ OrderedFactor{2}              │ CategoricalValue ⋯
│ tumor                     │ OrderedFactor{2}              │ CategoricalValue ⋯
│ psych                     │ OrderedFactor{2}              │ CategoricalValue ⋯
│ TSH_measured              │ OrderedFactor{2}              │ CategoricalValue ⋯
│ ⋮                         │ ⋮                             │ ⋮                ⋱
└───────────────────────────┴───────────────────────────────┴───────────────────
                                                    1 column and 11 rows omitted
```

This PR fixes this.